### PR TITLE
distinguish FastRPC type `binary` by native JS class `ArrayBuffer`; distinguish FastRPC type `double` by non-native JS class `Double`

### DIFF
--- a/frpc.d.ts
+++ b/frpc.d.ts
@@ -17,6 +17,7 @@ export type SerializableData =
     boolean |
     number |
     string |
+    ArrayBuffer |
     Date |
     Double |
     readonly SerializableData[] |
@@ -36,17 +37,41 @@ export type RpcDataTypeHint =
     {readonly [propertyPath: string]: RpcScalarDataTypeHint}
 
 /**
- * @deprecated Do not treat FastRPC type `double` as native JS type `number` with hint. Treat FastRPC type `double` as
- * non-native JS class `Double` instead.
+ * @deprecated Do not treat FastRPC type `binary`, type `double` respectively, as native JS class `Array`,
+ * type `number` respectively, with hint. Treat FastRPC type `binary`, type `double` respectively, as native JS
+ * class `ArrayBuffer`, non-native JS class `Double` respectively, instead.
  */
 export function serializeCall(procedure: string, args: readonly RpcData[], dataTypeHint: RpcDataTypeHint): number[]
-export function serializeCall(procedure: string, args: readonly SerializableData[], dataTypeHint: RpcDataTypeHint): number[]
+export function serializeCall(procedure: string, args: readonly SerializableData[]): number[]
 
 /**
- * @deprecated Do not treat FastRPC type `double` as native JS type `number` with hint. Treat FastRPC type `double` as
- * non-native JS class `Double` instead.
+ * @deprecated Do not treat FastRPC type `binary`, type `double` respectively, as native JS class `Array`,
+ * type `number` respectively, with hint. Treat FastRPC type `binary`, type `double` respectively, as native JS
+ * class `ArrayBuffer`, non-native JS class `Double` respectively, instead.
  */
 export function serialize(data: RpcData, typeHint: RpcDataTypeHint): number[]
-export function serialize(data: SerializableData, typeHint: RpcDataTypeHint): number[]
+export function serialize(data: SerializableData): number[]
 
+export type ParseOptions = {readonly arrayBuffers?: boolean}
+
+export type ParsedData =
+    null |
+    boolean |
+    number |
+    string |
+    ArrayBuffer |
+    Date |
+    readonly ParsedData[] |
+    {readonly [TKey: string]: ParsedData}
+
+export type ParsedCall = {
+    method: string,
+    params: ParsedData[]
+}
+
+/**
+ * @deprecated Do not treat FastRPC type `binary` as native JS class `Array`. Treat FastRPC type `binary` as native JS
+ * class `ArrayBuffer` instead.
+ */
 export function parse(data: readonly number[]): RpcData | {method: string, params: RpcData[]}
+export function parse(data: readonly number[], options?: ParseOptions): ParsedData | ParsedCall

--- a/frpc.d.ts
+++ b/frpc.d.ts
@@ -1,3 +1,8 @@
+export class Double {
+    number: number;
+    constructor(number: number);
+}
+
 export type RpcData =
     null |
     boolean |
@@ -6,6 +11,16 @@ export type RpcData =
     Date |
     readonly RpcData[] |
     {readonly [property: string]: RpcData}
+
+export type SerializableData =
+    null |
+    boolean |
+    number |
+    string |
+    Date |
+    Double |
+    readonly SerializableData[] |
+    {readonly [TKey: string]: SerializableData}
 
 type RpcScalarDataTypeHint =
     'binary' |
@@ -20,6 +35,18 @@ export type RpcDataTypeHint =
     RpcScalarDataTypeHint |
     {readonly [propertyPath: string]: RpcScalarDataTypeHint}
 
+/**
+ * @deprecated Do not treat FastRPC type `double` as native JS type `number` with hint. Treat FastRPC type `double` as
+ * non-native JS class `Double` instead.
+ */
 export function serializeCall(procedure: string, args: readonly RpcData[], dataTypeHint: RpcDataTypeHint): number[]
+export function serializeCall(procedure: string, args: readonly SerializableData[], dataTypeHint: RpcDataTypeHint): number[]
+
+/**
+ * @deprecated Do not treat FastRPC type `double` as native JS type `number` with hint. Treat FastRPC type `double` as
+ * non-native JS class `Double` instead.
+ */
 export function serialize(data: RpcData, typeHint: RpcDataTypeHint): number[]
+export function serialize(data: SerializableData, typeHint: RpcDataTypeHint): number[]
+
 export function parse(data: readonly number[]): RpcData | {method: string, params: RpcData[]}

--- a/frpc.js
+++ b/frpc.js
@@ -19,6 +19,13 @@
     var TYPE_ARRAY     = 11;
     var TYPE_NULL      = 12;
 
+    /**
+     * @param {number} number
+     */
+    var Double = function(number) {
+        this.number = number;
+    };
+
     var _hints = null;
     var _path = [];
     var _data = [];
@@ -84,12 +91,22 @@
     };
 
     /**
+     * @deprecated Do not treat FastRPC type `double` as native JS type `number` with hint. Treat FastRPC type `double`
+     * as non-native JS class `Double` instead.
      * @param {string} method
      * @param {array} data
      * @param {object || string} hints Napoveda datovych typu:
      * pokud string, pak typ (skalarni) hodnoty "data". Pokud objekt,
      * pak mnozina dvojic "cesta":"datovy typ"; cesta je teckami dodelena posloupnost
      * klicu a/nebo indexu v datech. Typ je "float" nebo "binary".
+     *//**
+     * @param {string} method
+     * @param {array} data
+     * @param {object || string} hints Napoveda datovych typu:
+     * pokud string, pak typ (skalarni) hodnoty "data". Pokud objekt,
+     * pak mnozina dvojic "cesta":"datovy typ"; cesta je teckami dodelena posloupnost
+     * klicu a/nebo indexu v datech. Typ je "binary".
+     * @returns {number[]}
      */
     var serializeCall = function(method, data, hints) {
         var result = serialize(data, hints);
@@ -108,9 +125,14 @@
     };
 
     /**
-     * @param {string} method
+     * @deprecated Do not treat FastRPC type `double` as native JS type `number` with hint. Treat FastRPC type `double`
+     * as non-native JS class `Double` instead.
      * @param {?} data
      * @param {object} hints hinty, ktera cisla maji byt floaty a kde jsou binarni data (klic = cesta, hodnota = "float"/"binary")
+     * @returns {number[]}
+     *//**
+     * @param {?} data
+     * @param {object} hints hinty, ktera cisla maji byt floaty a kde jsou binarni data (klic = cesta, hodnota = "binary")
      * @returns {number[]}
      */
     var serialize = function(data, hints) {
@@ -371,11 +393,7 @@
 
             case "number":
                 if (_getHint() == "float") { /* float */
-                    var first = TYPE_DOUBLE << 3;
-                    var floatData = _encodeDouble(value);
-
-                    result.push(first);
-                    _append(result, floatData);
+                    _serializeAsDouble(result, value);
                 } else { /* int */
                     var first = (value >= 0 ? TYPE_INT8P : TYPE_INT8N);
                     first = first << 3;
@@ -408,6 +426,8 @@
                     _serializeDate(result, value);
                 } else if (value instanceof Array) {
                     _serializeArray(result, value);
+                } else if (value instanceof Double) {
+                    _serializeAsDouble(result, value.number);
                 } else {
                     _serializeStruct(result, value);
                 }
@@ -498,6 +518,14 @@
         result.push( ((hours & 0x1e) >> 1) | ((day & 0x0f) << 4) );
         result.push( ((day & 0x1f) >> 4) | ((month & 0x0f) << 1) | ((year & 0x07) << 5) );
         result.push( (year & 0x07f8) >> 3 );
+    };
+
+    var _serializeAsDouble = function(result, number) {
+        var first = TYPE_DOUBLE << 3;
+        var floatData = _encodeDouble(number);
+
+        result.push(first);
+        _append(result, floatData);
     };
 
     /**
@@ -592,6 +620,7 @@
     };
 
     var PublicExports = {
+        Double: Double,
         serializeCall: serializeCall,
         serialize: serialize,
         parse: parse

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "Ondřej Žára <ondrej.zara@gmail.com>",
     "David Rus <david.rus@me.com>",
     "Juraj Hájovský <juraj@hajovsky.sk>",
-    "Martin Jurča <martin.jurca@firma.seznam.cz>"
+    "Martin Jurča <martin.jurca@firma.seznam.cz>",
+    "tearwyx <dev@tearwyx.com>"
   ]
 }

--- a/test.js
+++ b/test.js
@@ -10,10 +10,10 @@ var params = [
     123,                                 // int
     true,                                // bool
     false,                               // bool
-    (100).toFixed(2),                    // double
+    100,                                 // double
     "Name",                              // string
     new Date(testDate),                  // datetime
-    101 >> 1,                            // binary
+    [69, 96],                            // binary
     567188429000,                        // positive
     -567188429000,                       // negative
     {                                    // struct
@@ -25,7 +25,7 @@ var params = [
     null                                 // null
 ];
 
-var testDataBase64 = "yhECAWgGbWV0aG9kOHsRECAGMTAwLjAwIAROYW1lKADNm84h6ihoeTA4MjzImBAPhETImBAPhFADBG5hbWUgBURhdmlkB3N1cm5hbWUgA1J1cwRkYXRlKADNm84h6ihoeTBYA0AAOAEgBHRleHRg";
+var testDataBase64 = "yhECAWgGbWV0aG9kOHsREBgAAAAAAABZQCAETmFtZSj8zZvOIeqoaHkwMAJFYDzImBAPhETImBAPhFADBG5hbWUgBURhdmlkB3N1cm5hbWUgA1J1cwRkYXRlKPzNm84h6qhoeTBYAzgAOAEgBHRleHRg";
 var testDataBuffer = new Buffer(testDataBase64, 'base64');
 
 before(function() {
@@ -61,14 +61,14 @@ describe('node-fastrpc', function() {
         });
     });
 
-    describe('methods', function(){
-        it('serializeCall()', function(){
-            var bin = frpc.serializeCall(method, params);
+    describe('methods', function() {
+        it('serializeCall()', function() {
+            var bin = frpc.serializeCall(method, params, {'3':'float', '6':'binary'});
             var data = new Buffer(bin);
             expect(data).to.deep.equal(testDataBuffer);
         });
 
-        it('parse()', function(){
+        it('parse()', function() {
             var data = frpc.parse(testDataBuffer);
             expect(data.method).to.be.equal(method);
             expect(JSON.stringify(data.params)).to.deep.equal(JSON.stringify(params));

--- a/test.js
+++ b/test.js
@@ -11,6 +11,7 @@ var params = [
     true,                                // bool
     false,                               // bool
     100,                                 // double
+    new frpc.Double(100),                // double
     "Name",                              // string
     new Date(testDate),                  // datetime
     [69, 96],                            // binary
@@ -25,8 +26,16 @@ var params = [
     null                                 // null
 ];
 
-var testDataBase64 = "yhECAWgGbWV0aG9kOHsREBgAAAAAAABZQCAETmFtZSj8zZvOIeqoaHkwMAJFYDzImBAPhETImBAPhFADBG5hbWUgBURhdmlkB3N1cm5hbWUgA1J1cwRkYXRlKPzNm84h6qhoeTBYAzgAOAEgBHRleHRg";
+var testDataBase64 = "yhECAWgGbWV0aG9kOHsREBgAAAAAAABZQBgAAAAAAABZQCAETmFtZSj8zZvOIeqoaHkwWAI4RThgPMiYEA+ERMiYEA+EUAMEbmFtZSAFRGF2aWQHc3VybmFtZSADUnVzBGRhdGUo/M2bziHqqGh5MFgDOAA4ASAEdGV4dGA=";
 var testDataBuffer = new Buffer(testDataBase64, 'base64');
+
+var replacer = function(_key, value) {
+    if (value instanceof frpc.Double) {
+        return value.number;
+    }
+
+    return value;
+};
 
 before(function() {
     // Force UTC as a local timezone
@@ -63,7 +72,7 @@ describe('node-fastrpc', function() {
 
     describe('methods', function() {
         it('serializeCall()', function() {
-            var bin = frpc.serializeCall(method, params, {'3':'float', '6':'binary'});
+            var bin = frpc.serializeCall(method, params, {'3':'float', '7':'binary'});
             var data = new Buffer(bin);
             expect(data).to.deep.equal(testDataBuffer);
         });
@@ -71,7 +80,7 @@ describe('node-fastrpc', function() {
         it('parse()', function() {
             var data = frpc.parse(testDataBuffer);
             expect(data.method).to.be.equal(method);
-            expect(JSON.stringify(data.params)).to.deep.equal(JSON.stringify(params));
+            expect(JSON.stringify(data.params, replacer)).to.deep.equal(JSON.stringify(params, replacer));
         });
     });
 });


### PR DESCRIPTION
So-called hints are painful. Let's demonstrate the absurdity of hints in one of the worst scenarios for FastRPC type `double`:

```ts
const items = [
  { value: 1 },
  { value: 1.1 },
  { value: 1.11 },
];

const hints = {
  '0.value': 'float',
  '1.value': 'float',
  '2.value': 'float',
};

fastrpc.serialize(items, hints);
```

That's terrible.

Another absurdity of this method is the impossibility (or the possibility, I can no longer imagine) of static type checking in the TypeScript.

I propose to implement a non-native JavaScript class for FastRPC type `double`. Example:

```ts
const remoteItems = items.map((item) => ({
  ...item,
  value: new fastrpc.Double(item.value),
}));

fastrpc.serialize(remoteItems);
```

Obvious advantage of this method is the possibility of static type checking in the TypeScript. 

To avoid hints completely, PR also adds a native JavaScript class for FastRPC type `binary`.

Hints are retained for backward compatibility and sadomasochists.